### PR TITLE
fix Bypass manifest

### DIFF
--- a/bucket/ByPass.json
+++ b/bucket/ByPass.json
@@ -1,15 +1,15 @@
 {
     "homepage": "https://www.bypass.cn/",
     "version": "1.14.98",
-    "url": "https://www.bypass.cn/api/download?name=Bypass.zip",
-    "hash": "8b439579926c9eb7563056631671476141aaa47d9a15d0e33a8cfd6e0d2fa72e",
+    "url": "https://www.bypass.cn/api/download?name=Bypass.zip#/dl.zip",
+    "hash": "f4039c5cf1972017cfb63e26e116c560416f99cc0dc8633011af57feeb310609",
     "extract_dir": "Bypass",
     "checkver": {
         "url": "https://www.bypass.cn/",
         "regex": "Version&#xFF1A;([\\d.]+)"
     },
     "autoupdate": {
-        "url": "https://www.bypass.cn/api/download?name=Bypass.zip"
+        "url": "https://www.bypass.cn/api/download?name=Bypass.zip#/dl.zip"
     },
     "shortcuts": [
         [


### PR DESCRIPTION
The current installation of Bypass is broken due to: 1) wrong archive name, 2) wrong hash.

This PR fixes the above problems and tested on my PC.